### PR TITLE
Fix phe and hpo with TabPFN API

### DIFF
--- a/src/tabpfn_extensions/__init__.py
+++ b/src/tabpfn_extensions/__init__.py
@@ -6,6 +6,6 @@ except PackageNotFoundError:
     __version__ = "0.1.0.dev0"
 
 from .utils import is_tabpfn
-from .utils import TabPFNRegressor, TabPFNClassifier, PreprocessorConfig
+from .utils import TabPFNRegressor, TabPFNClassifier
 
 from . import utils_todo

--- a/src/tabpfn_extensions/hpo/search_space.py
+++ b/src/tabpfn_extensions/hpo/search_space.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from hyperopt import hp
 from pathlib import Path
-from tabpfn_extensions import PreprocessorConfig
 
 
 def enumerate_preprocess_transforms():
@@ -47,13 +46,13 @@ def enumerate_preprocess_transforms():
                     for global_transformer_name in [None, "svd"]:
                         transforms += [
                             [
-                                PreprocessorConfig(
-                                    name=name,
-                                    global_transformer_name=global_transformer_name,
-                                    subsample_features=subsample_features,
-                                    categorical_name=categorical_name,
-                                    append_original=append_original,
-                                )
+                                {
+                                    "name": name,
+                                    "global_transformer_name": global_transformer_name,
+                                    "subsample_features": subsample_features,
+                                    "categorical_name": categorical_name,
+                                    "append_original": append_original,
+                                }
                                 for name in names
                             ],
                         ]

--- a/src/tabpfn_extensions/utils.py
+++ b/src/tabpfn_extensions/utils.py
@@ -4,8 +4,9 @@
 import os
 
 import os
-from typing import Any, Type, Tuple, Protocol
-
+from typing import Any, Type, Tuple, Protocol, Literal
+from dataclasses import dataclass
+from typing_extensions import override
 
 class TabPFNEstimator(Protocol):
     def fit(self, X: Any, y: Any) -> Any:
@@ -28,6 +29,98 @@ def is_tabpfn(estimator: Any) -> bool:
         )
     except (AttributeError, TypeError):
         return False
+    
+
+@dataclass
+class PreprocessorConfigDefault:
+    """Configuration for data preprocessors.
+
+    Attributes:
+        name: Name of the preprocessor.
+        categorical_name:
+            Name of the categorical encoding method.
+            Options: "none", "numeric", "onehot", "ordinal", "ordinal_shuffled", "none".
+        append_original: Whether to append original features to the transformed features
+        subsample_features: Fraction of features to subsample. -1 means no subsampling.
+        global_transformer_name: Name of the global transformer to use.
+    """
+
+    name: Literal[
+        "per_feature",  # a different transformation for each feature
+        "power",  # a standard sklearn power transformer
+        "safepower",  # a power transformer that prevents some numerical issues
+        "power_box",
+        "safepower_box",
+        "quantile_uni_coarse",  # quantile transformations with few quantiles up to many
+        "quantile_norm_coarse",
+        "quantile_uni",
+        "quantile_norm",
+        "quantile_uni_fine",
+        "quantile_norm_fine",
+        "robust",  # a standard sklearn robust scaler
+        "kdi",
+        "none",  # no transformation (only standardization in transformer)
+        "kdi_random_alpha",
+        "kdi_uni",
+        "kdi_random_alpha_uni",
+        "adaptive",
+        "norm_and_kdi",
+        # KDI with alpha collection
+        "kdi_alpha_0.3_uni",
+        "kdi_alpha_0.5_uni",
+        "kdi_alpha_0.8_uni",
+        "kdi_alpha_1.0_uni",
+        "kdi_alpha_1.2_uni",
+        "kdi_alpha_1.5_uni",
+        "kdi_alpha_2.0_uni",
+        "kdi_alpha_3.0_uni",
+        "kdi_alpha_5.0_uni",
+        "kdi_alpha_0.3",
+        "kdi_alpha_0.5",
+        "kdi_alpha_0.8",
+        "kdi_alpha_1.0",
+        "kdi_alpha_1.2",
+        "kdi_alpha_1.5",
+        "kdi_alpha_2.0",
+        "kdi_alpha_3.0",
+        "kdi_alpha_5.0",
+    ]
+    categorical_name: Literal[
+        # categorical features are pretty much treated as ordinal, just not resorted
+        "none",
+        # categorical features are treated as numeric,
+        # that means they are also power transformed for example
+        "numeric",
+        # "onehot": categorical features are onehot encoded
+        "onehot",
+        # "ordinal": categorical features are sorted and encoded as
+        # integers from 0 to n_categories - 1
+        "ordinal",
+        # "ordinal_shuffled": categorical features are encoded as integers
+        # from 0 to n_categories - 1 in a random order
+        "ordinal_shuffled",
+        "ordinal_very_common_categories_shuffled",
+    ] = "none"
+    append_original: bool = False
+    subsample_features: float = -1
+    global_transformer_name: str | None = None
+
+    @override
+    def __str__(self) -> str:
+        return (
+            f"{self.name}_cat:{self.categorical_name}"
+            + ("_and_none" if self.append_original else "")
+            + (
+                f"_subsample_feats_{self.subsample_features}"
+                if self.subsample_features > 0
+                else ""
+            )
+            + (
+                f"_global_transformer_{self.global_transformer_name}"
+                if self.global_transformer_name is not None
+                else ""
+            )
+        )
 
 
 from typing import Tuple, Type
@@ -50,9 +143,6 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
             TabPFNClassifier as ClientTabPFNClassifier,
             TabPFNRegressor as ClientTabPFNRegressor,
         )
-        from tabpfn_client.estimator import (
-            PreprocessorConfig as ClientPreprocessorConfig,
-        )
 
         # Wrapper classes to add device parameter
         class TabPFNClassifier(ClientTabPFNClassifier):
@@ -65,7 +155,7 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
                 super().__init__(*args, **kwargs)
                 # Ignoring the device parameter for now
 
-        return TabPFNClassifier, TabPFNRegressor, ClientPreprocessorConfig
+        return TabPFNClassifier, TabPFNRegressor, PreprocessorConfigDefault
 
     except ImportError:
         raise ImportError(

--- a/src/tabpfn_extensions/utils.py
+++ b/src/tabpfn_extensions/utils.py
@@ -42,9 +42,8 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
     if USE_TABPFN_LOCAL:
         try:
             from tabpfn import TabPFNClassifier, TabPFNRegressor
-            from tabpfn.preprocessing import PreprocessorConfig
 
-            return TabPFNClassifier, TabPFNRegressor, PreprocessorConfig
+            return TabPFNClassifier, TabPFNRegressor
         except ImportError:
             pass
 
@@ -53,7 +52,6 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
             TabPFNClassifier as ClientTabPFNClassifier,
             TabPFNRegressor as ClientTabPFNRegressor,
         )
-        from tabpfn_client.tabpfn_common_utils.utils import PreprocessorConfig
 
 
         # Wrapper classes to add device parameter
@@ -155,7 +153,7 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
                 params.pop("categorical_features_indices")
                 return params
 
-        return TabPFNClassifierWrapper, TabPFNRegressorWrapper, PreprocessorConfig
+        return TabPFNClassifierWrapper, TabPFNRegressorWrapper
 
     except ImportError:
         raise ImportError(
@@ -166,4 +164,4 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
         )
 
 
-TabPFNClassifier, TabPFNRegressor, PreprocessorConfig = get_tabpfn_models()
+TabPFNClassifier, TabPFNRegressor = get_tabpfn_models()

--- a/src/tabpfn_extensions/utils.py
+++ b/src/tabpfn_extensions/utils.py
@@ -147,8 +147,9 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
             TabPFNRegressor as ClientTabPFNRegressor,
         )
 
+
         # Wrapper classes to add device parameter
-        class TabPFNClassifier(ClientTabPFNClassifier, BaseEstimator):
+        class TabPFNClassifierWrapper(ClientTabPFNClassifier):
             def __init__(
                 self,
                 device: str | None = None,
@@ -163,7 +164,7 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
                 inference_config: Optional[Dict] = None,
                 paper_version: bool = False,
             ) -> None:
-                self.device = device  # This will appear in get_params
+                self.device = device
                 super().__init__(
                     model_path=model_path,
                     n_estimators=n_estimators,
@@ -177,7 +178,17 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
                     paper_version=paper_version,
                 )
 
-        class TabPFNRegressor(ClientTabPFNRegressor, BaseEstimator):
+            def get_params(self, deep: bool = True) -> Dict[str, Any]:
+                """
+                Return parameters for this estimator.
+                """
+                params = super().get_params(deep=deep)
+                params.pop("device")
+                # Add any parameters that are stored only in this class.
+                return params
+
+
+        class TabPFNRegressorWrapper(ClientTabPFNRegressor):
             def __init__(
                 self,
                 device: str | None = None,
@@ -191,8 +202,7 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
                 inference_config: Optional[Dict] = None,
                 paper_version: bool = False,
             ) -> None:
-                self.device = device  # Keep this for get_params() compatibility
-                # Pass all recognized arguments to the parent constructor.
+                self.device = device
                 super().__init__(
                     model_path=model_path,
                     n_estimators=n_estimators,
@@ -205,7 +215,15 @@ def get_tabpfn_models() -> Tuple[Type, Type, Type]:
                     paper_version=paper_version,
                 )
 
-        return TabPFNClassifier, TabPFNRegressor, PreprocessorConfigDefault
+            def get_params(self, deep: bool = True) -> Dict[str, Any]:
+                """
+                Return parameters for this estimator.
+                """
+                params = super().get_params(deep=deep)
+                params.pop("device")
+                return params
+
+        return TabPFNClassifierWrapper, TabPFNRegressorWrapper, PreprocessorConfigDefault
 
     except ImportError:
         raise ImportError(


### PR DESCRIPTION
The PHE and HPO break in a bunch of way with the client. This PR (jointly with a [server PR](https://github.com/automl/tabpfn-server/pull/135) and a [client PR](https://github.com/PriorLabs/tabpfn-client/pull/75) fix these issues. This `tabpfn-extensions` PR:
- import PreprocessorConfig from the right place
- fix the wrapper to make it work (you need to pass all the params in the constructor) and to support `categorical_features_indices` (the client doesn't use it for now so we just output a warning)