### PR TITLE
Fix float32 error in RandomForestTabPFN

### DIFF
--- a/src/tabpfn_extensions/rf_pfn/SklearnBasedDecisionTreeTabPFN.py
+++ b/src/tabpfn_extensions/rf_pfn/SklearnBasedDecisionTreeTabPFN.py
@@ -794,6 +794,67 @@ class DecisionTreeTabPFNRegressor(RegressorMixin, DecisionTreeTabPFNBase):
 
     task_type = "regression"
 
+    def __init__(
+        self,
+        *,
+        # Decision Tree Arguments
+        criterion="squared_error",
+        splitter="best",
+        max_depth=None,
+        min_samples_split=1000,
+        min_samples_leaf=1,
+        min_weight_fraction_leaf=0.0,
+        max_features=None,
+        random_state=None,
+        max_leaf_nodes=None,
+        min_impurity_decrease=0.0,
+        ccp_alpha=0.0,
+        monotonic_cst=None,
+        # TabPFN Arguments
+        tabpfn=None,
+        categorical_features=None,
+        verbose=False,
+        show_progress=False,
+        fit_nodes=True,
+        tree_seed=0,
+        adaptive_tree=True,
+        adaptive_tree_min_train_samples=50,
+        adaptive_tree_max_train_samples=2000,
+        adaptive_tree_min_valid_samples_fraction_of_train=0.2,
+        adaptive_tree_overwrite_metric=None,
+        adaptive_tree_test_size=0.2,
+        average_logits=True,
+        adaptive_tree_skip_class_missing=True,
+    ):
+        super().__init__(
+            criterion=criterion,
+            splitter=splitter,
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            min_weight_fraction_leaf=min_weight_fraction_leaf,
+            max_features=max_features,
+            random_state=random_state,
+            max_leaf_nodes=max_leaf_nodes,
+            min_impurity_decrease=min_impurity_decrease,
+            ccp_alpha=ccp_alpha,
+            monotonic_cst=monotonic_cst,
+            tabpfn=tabpfn,
+            categorical_features=categorical_features,
+            verbose=verbose,
+            show_progress=show_progress,
+            fit_nodes=fit_nodes,
+            tree_seed=tree_seed,
+            adaptive_tree=adaptive_tree,
+            adaptive_tree_min_train_samples=adaptive_tree_min_train_samples,
+            adaptive_tree_max_train_samples=adaptive_tree_max_train_samples,
+            adaptive_tree_min_valid_samples_fraction_of_train=adaptive_tree_min_valid_samples_fraction_of_train,
+            adaptive_tree_overwrite_metric=adaptive_tree_overwrite_metric,
+            adaptive_tree_test_size=adaptive_tree_test_size,
+            average_logits=average_logits,
+            adaptive_tree_skip_class_missing=adaptive_tree_skip_class_missing,
+        )
+
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True

--- a/src/tabpfn_extensions/rf_pfn/SklearnBasedRandomForestTabPFN.py
+++ b/src/tabpfn_extensions/rf_pfn/SklearnBasedRandomForestTabPFN.py
@@ -44,9 +44,6 @@ class RandomForestTabPFNBase:
     def get_n_estimators(self, X):
         return self.n_estimators
 
-    def _more_tags(self):
-        return {"multilabel": True, "allow_nan": True}
-
     def set_categorical_features(self, categorical_features):
         """Sets categorical features
         :param categorical_features: Categorical features
@@ -307,9 +304,15 @@ class RandomForestTabPFNClassifier(RandomForestTabPFNBase, RandomForestClassifie
 
 
 class RandomForestTabPFNRegressor(RandomForestTabPFNBase, RandomForestRegressor):
-    """RandomForestTabPFNClassifier."""
+    """RandomForestTabPFNRegressor."""
 
     task_type = "regression"
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        tags.estimator_type = "regressor"
+        return tags
 
     def __init__(
         self,

--- a/src/tabpfn_extensions/rf_pfn/SklearnBasedRandomForestTabPFN.py
+++ b/src/tabpfn_extensions/rf_pfn/SklearnBasedRandomForestTabPFN.py
@@ -41,21 +41,6 @@ def softmax_numpy(logits):
 class RandomForestTabPFNBase:
     """Base Class for common functionalities."""
 
-    def _validate_X_predict(self, X):
-        """Validate X whenever one tries to predict, apply, predict_proba."""
-        return X
-
-    def _validate_data(
-        self,
-        X,
-        y,
-        reset=True,
-        validate_separately=False,
-        **check_params,
-    ):
-        """Validate X and y whenever one tries to fit, predict, apply, predict_proba."""
-        return X, y
-
     def get_n_estimators(self, X):
         return self.n_estimators
 

--- a/src/tabpfn_extensions/rf_pfn/SklearnBasedRandomForestTabPFN.py
+++ b/src/tabpfn_extensions/rf_pfn/SklearnBasedRandomForestTabPFN.py
@@ -47,10 +47,6 @@ class RandomForestTabPFNBase:
     def _more_tags(self):
         return {"multilabel": True, "allow_nan": True}
 
-    def _fit(self, X, y, sample_weight=None):
-        self.X = X
-        self.fit(X, y, sample_weight=sample_weight)
-
     def set_categorical_features(self, categorical_features):
         """Sets categorical features
         :param categorical_features: Categorical features

--- a/tests/test_rf_pfn.py
+++ b/tests/test_rf_pfn.py
@@ -78,33 +78,3 @@ def test_with_nan(model_class):
         assert np.all(np.isin(pred, [0, 1]))
     else:
         assert pred.dtype == np.float64
-
-# @parametrize_with_checks([RandomForestTabPFNClassifier(tabpfn=TabPFNClassifier(), n_estimators=2, max_depth=2)])
-# def test_sklearn_rf_classifier_checks(estimator, check):
-#     """Test if RandomForestTabPFNClassifier complies with scikit-learn's estimator API."""
-#     if "sample_weight" in check.func.__name__:  # type: ignore
-#         pytest.xfail("Sample weights not supported")
-#     check(estimator)
-
-# @parametrize_with_checks([RandomForestTabPFNRegressor(tabpfn=TabPFNRegressor(), n_estimators=2, max_depth=2)])
-# def test_sklearn_rf_regressor_checks(estimator, check):
-#     """Test if RandomForestTabPFNRegressor complies with scikit-learn's estimator API."""
-#     if "sample_weight" in check.func.__name__:  # type: ignore
-#         pytest.xfail("Sample weights not supported")
-#     check(estimator)
-
-# @parametrize_with_checks([DecisionTreeTabPFNClassifier(tabpfn=TabPFNClassifier(), max_depth=2)])
-# def test_sklearn_dt_classifier_checks(estimator, check):
-#     """Test if DecisionTreeTabPFNClassifier complies with scikit-learn's estimator API."""
-#     if "sample_weight" in check.func.__name__:  # type: ignore
-#         pytest.xfail("Sample weights not supported")
-#     check(estimator)
-
-# #@parametrize_with_checks([DecisionTreeTabPFNRegressor(tabpfn=TabPFNRegressor(), max_depth=2)])
-# #def test_sklearn_dt_regressor_checks(estimator, check):
-# #    """Test if DecisionTreeTabPFNRegressor complies with scikit-learn's estimator API."""
-# #    if "sample_weight" in check.func.__name__:  # type: ignore
-# #        pytest.xfail("Sample weights not supported")
-# #    check(estimator)
-
-

--- a/tests/test_rf_pfn.py
+++ b/tests/test_rf_pfn.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+from tabpfn_extensions.rf_pfn import (
+    RandomForestTabPFNClassifier,
+    DecisionTreeTabPFNClassifier,
+    RandomForestTabPFNRegressor,
+    #DecisionTreeTabPFNRegressor, #broken
+)
+from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor
+
+@pytest.mark.parametrize("model_class", [
+    (RandomForestTabPFNClassifier, TabPFNClassifier),
+    (RandomForestTabPFNRegressor, TabPFNRegressor),
+    (DecisionTreeTabPFNClassifier, TabPFNClassifier),
+    #(DecisionTreeTabPFNRegressor, TabPFNRegressor)
+])
+def test_sklearn_compatibility(model_class):
+    """Test RandomForestTabPFN compatibility with different sklearn versions."""
+    # Generate sample data
+    rng = np.random.RandomState(42)
+    X = rng.rand(100, 4)
+    y = rng.randint(0, 2, 100)
+    
+    # Initialize classifier
+    clf_class, clf_base_class = model_class
+    clf_base = clf_base_class()
+    kwargs = {
+        "tabpfn": clf_base,
+        **({"n_estimators": 2} if "RandomForest" in clf_class.__name__ else {}),  # Only add n_estimators for RandomForest
+        "max_depth": 2
+    }
+    clf = clf_class(**kwargs)
+    
+    # This should work without errors on both sklearn <1.6 and >=1.6
+    clf.fit(X, y)
+    
+    # Verify predictions work
+    pred = clf.predict(X)
+    assert pred.shape == (100,)
+    if clf_base_class == TabPFNClassifier:
+        assert np.all(np.isin(pred, [0, 1]))
+    else:
+        assert pred.dtype == np.float64
+
+@pytest.mark.parametrize("model_class", [
+    (RandomForestTabPFNClassifier, TabPFNClassifier),
+    (RandomForestTabPFNRegressor, TabPFNRegressor),
+    (DecisionTreeTabPFNClassifier, TabPFNClassifier),
+    #(DecisionTreeTabPFNRegressor, TabPFNRegressor)
+])
+def test_with_nan(model_class):
+    """Test handling of float64 data with NaN values for sklearn < 1.6."""
+    # Generate sample data with NaN values
+    rng = np.random.RandomState(42)
+    X = rng.rand(100, 4)
+    X[0, 0] = np.nan  # Add a NaN value
+    y = rng.randint(0, 2, 100)
+    
+    clf_class, clf_base_class = model_class
+    clf_base = clf_base_class()
+    kwargs = {
+        "tabpfn": clf_base,
+        **({"n_estimators": 2} if "RandomForest" in clf_class.__name__ else {}),
+        "max_depth": 2
+    }
+    clf = clf_class(**kwargs)
+    
+    # This should work without errors
+    clf.fit(X, y)
+    
+    # Test prediction with NaN values
+    X_test = X.copy()
+    pred = clf.predict(X_test)
+    
+    assert pred.shape == (100,)
+    if clf_base_class == TabPFNClassifier:
+        assert np.all(np.isin(pred, [0, 1]))
+    else:
+        assert pred.dtype == np.float64
+

--- a/tests/test_rf_pfn.py
+++ b/tests/test_rf_pfn.py
@@ -50,7 +50,7 @@ def test_sklearn_compatibility(model_class):
     (DecisionTreeTabPFNRegressor, TabPFNRegressor)
 ])
 def test_with_nan(model_class):
-    """Test handling of float64 data with NaN values for sklearn < 1.6."""
+    """Test handling of NaN values for sklearn < 1.6."""
     # Generate sample data with NaN values
     rng = np.random.RandomState(42)
     X = rng.rand(100, 4)
@@ -78,3 +78,33 @@ def test_with_nan(model_class):
         assert np.all(np.isin(pred, [0, 1]))
     else:
         assert pred.dtype == np.float64
+
+# @parametrize_with_checks([RandomForestTabPFNClassifier(tabpfn=TabPFNClassifier(), n_estimators=2, max_depth=2)])
+# def test_sklearn_rf_classifier_checks(estimator, check):
+#     """Test if RandomForestTabPFNClassifier complies with scikit-learn's estimator API."""
+#     if "sample_weight" in check.func.__name__:  # type: ignore
+#         pytest.xfail("Sample weights not supported")
+#     check(estimator)
+
+# @parametrize_with_checks([RandomForestTabPFNRegressor(tabpfn=TabPFNRegressor(), n_estimators=2, max_depth=2)])
+# def test_sklearn_rf_regressor_checks(estimator, check):
+#     """Test if RandomForestTabPFNRegressor complies with scikit-learn's estimator API."""
+#     if "sample_weight" in check.func.__name__:  # type: ignore
+#         pytest.xfail("Sample weights not supported")
+#     check(estimator)
+
+# @parametrize_with_checks([DecisionTreeTabPFNClassifier(tabpfn=TabPFNClassifier(), max_depth=2)])
+# def test_sklearn_dt_classifier_checks(estimator, check):
+#     """Test if DecisionTreeTabPFNClassifier complies with scikit-learn's estimator API."""
+#     if "sample_weight" in check.func.__name__:  # type: ignore
+#         pytest.xfail("Sample weights not supported")
+#     check(estimator)
+
+# #@parametrize_with_checks([DecisionTreeTabPFNRegressor(tabpfn=TabPFNRegressor(), max_depth=2)])
+# #def test_sklearn_dt_regressor_checks(estimator, check):
+# #    """Test if DecisionTreeTabPFNRegressor complies with scikit-learn's estimator API."""
+# #    if "sample_weight" in check.func.__name__:  # type: ignore
+# #        pytest.xfail("Sample weights not supported")
+# #    check(estimator)
+
+

--- a/tests/test_rf_pfn.py
+++ b/tests/test_rf_pfn.py
@@ -4,15 +4,16 @@ from tabpfn_extensions.rf_pfn import (
     RandomForestTabPFNClassifier,
     DecisionTreeTabPFNClassifier,
     RandomForestTabPFNRegressor,
-    #DecisionTreeTabPFNRegressor, #broken
+    DecisionTreeTabPFNRegressor,
 )
 from tabpfn_extensions import TabPFNClassifier, TabPFNRegressor
+from sklearn.utils.estimator_checks import check_estimator, parametrize_with_checks
 
 @pytest.mark.parametrize("model_class", [
     (RandomForestTabPFNClassifier, TabPFNClassifier),
     (RandomForestTabPFNRegressor, TabPFNRegressor),
     (DecisionTreeTabPFNClassifier, TabPFNClassifier),
-    #(DecisionTreeTabPFNRegressor, TabPFNRegressor)
+    (DecisionTreeTabPFNRegressor, TabPFNRegressor)
 ])
 def test_sklearn_compatibility(model_class):
     """Test RandomForestTabPFN compatibility with different sklearn versions."""
@@ -46,7 +47,7 @@ def test_sklearn_compatibility(model_class):
     (RandomForestTabPFNClassifier, TabPFNClassifier),
     (RandomForestTabPFNRegressor, TabPFNRegressor),
     (DecisionTreeTabPFNClassifier, TabPFNClassifier),
-    #(DecisionTreeTabPFNRegressor, TabPFNRegressor)
+    (DecisionTreeTabPFNRegressor, TabPFNRegressor)
 ])
 def test_with_nan(model_class):
     """Test handling of float64 data with NaN values for sklearn < 1.6."""
@@ -77,4 +78,3 @@ def test_with_nan(model_class):
         assert np.all(np.isin(pred, [0, 1]))
     else:
         assert pred.dtype == np.float64
-


### PR DESCRIPTION
Fix https://github.com/PriorLabs/TabPFN/issues/162, which would appear when X contains NaNs and scikit-learn<1.6 + small fixes


https://github.com/PriorLabs/TabPFN/issues/162 is fixed by removing the `_validate_data` override from RandomForest. I also removed other overrides which do not seem useful.

I tried the scikit-learn `check_estimator` tests, and a lof them are failing for RandomForestTabPFN, but I that'll be a bigger PR!