### PR TITLE
Always use safepower instead of power to fix bracket errors

### DIFF
--- a/src/tabpfn_extensions/hpo/search_space.py
+++ b/src/tabpfn_extensions/hpo/search_space.py
@@ -19,7 +19,7 @@ def enumerate_preprocess_transforms():
         ["none"],
         ["robust"],
         ["safepower", "quantile_uni"],
-        ["none", "power"],
+        ["none", "safepower"],
     ]
 
     # try:
@@ -119,8 +119,7 @@ def get_param_grid_hyperopt(task_type: str) -> dict:
             "REGRESSION_Y_PREPROCESS_TRANSFORMS",
             [
                 (None,),
-                (None, "power"),
-                ("power",),
+                (None, "safepower"),
                 ("safepower",),
                 # ("kdi_alpha_0.3",),
                 # ("kdi_alpha_1.0",),


### PR DESCRIPTION
Fix https://github.com/PriorLabs/TabPFN/issues/183
I'm wondering why we didn't always use `safepower` before. For instance one of the search spaces contained both `safepower` and `power`, which is a bit confusing for me. So not 100% sure this fix is the right one.

Note that all of this will be fixed once our sklearn versions use scipy's yeo-johnson optimizer https://github.com/scikit-learn/scikit-learn/issues/26308